### PR TITLE
Fix is_resource returning false in php8

### DIFF
--- a/src/Connectors/CurlWrapper.php
+++ b/src/Connectors/CurlWrapper.php
@@ -21,7 +21,7 @@ class CurlWrapper
      */
     protected function getClient()
     {
-        if (!is_resource($this->client)) {
+        if (!is_resource($this->client) && !is_object($this->client)) {
             $this->client = curl_init();
         }
 


### PR DESCRIPTION
In PHP8 `is_resource(curl_init())` returns false. This causes `$this->client` to be overwritten each time `$this->getClient()` is called e.g in the `send` method of `GloBeeCurlConnector` which results in an error since no URL is set when `curl_exec($this->getClient())` is called.

This pull request adds `is_object()` to prevent `$this->client` being overwritten in PHP8.

Mentioned in this repo too - https://github.com/aliyun/aliyun-oss-php-sdk/pull/153

Tested and working on my server.